### PR TITLE
Increase Sentry worker memory to 1Gb

### DIFF
--- a/sentry/manifest.yml
+++ b/sentry/manifest.yml
@@ -33,7 +33,7 @@ applications:
         command: sentry run worker
         health-check-type: process
         instances: 1
-        memory: 256M
+        memory: 1GB
 
       - type: cron
         command: sentry run cron


### PR DESCRIPTION
Memory exhaustion causes worker to crash under high message volume