### PR TITLE
Set the HTTP health check endpoint on PgAdmin manifest

### DIFF
--- a/pgadmin/manifest.yml
+++ b/pgadmin/manifest.yml
@@ -6,6 +6,7 @@ applications:
         - python_buildpack
       command: ./install.sh
       health-check-type: http
+      health-check-http-endpoint: /login
       routes:
         - route: "((org))-((space))-pgadmin.london.cloudapps.digital"
       env:


### PR DESCRIPTION
What
---
Unauthenticated requests to `/` in PgAdmin4 are met with an HTTP 302 response
directing the requester to `/login`. CloudFoundry expects the health check
endpoint to respond with an HTTP 200. This had the side effect of causing
PgAdmin4 to fail its health check, despite being healthy.

How to review
---
1. Check I don't need to add any other manifest properties

Who can review
---
Anyone