### PR TITLE
Update Kong version and remove multi-buildpack

### DIFF
--- a/kong/apt.yml
+++ b/kong/apt.yml
@@ -6,4 +6,4 @@ packages:
 - perl
 - jq
 - ack-grep
-- https://bintray.com/kong/kong-deb/download_file?file_path=kong-2.0.1.bionic.amd64.deb
+- https://bintray.com/kong/kong-deb/download_file?file_path=kong-2.0.2.bionic.amd64.deb

--- a/kong/manifest.yml
+++ b/kong/manifest.yml
@@ -1,7 +1,9 @@
 ---
 applications:
 - name: cf-kong
-  buildpack: https://github.com/cloudfoundry/multi-buildpack/
+  buildpacks:
+  - https://github.com/cloudfoundry/apt-buildpack
+  - https://github.com/cloudfoundry/binary-buildpack
   command: ./run.sh
   services:
   - kong-db

--- a/kong/multi-buildpack.yml
+++ b/kong/multi-buildpack.yml
@@ -1,4 +1,0 @@
-buildpacks:
-- https://github.com/cloudfoundry/apt-buildpack
-- https://github.com/cloudfoundry/binary-buildpack
-


### PR DESCRIPTION
There has been a new version of kong shipped and the multi buildpack is
no longer required.