### PR TITLE
Persistent jaeger deployment

### DIFF
--- a/jaeger/README.md
+++ b/jaeger/README.md
@@ -2,15 +2,19 @@
 
 [Jaeger](https://www.jaegertracing.io/) is a distributed tracing and analysis server.
 
+## Demo
 The `demo.yml` manifest will deploy a `jaeger-all-in-one` instance using an in-memory database
 as well as an example application called [HotROD](https://medium.com/opentracing/take-opentracing-for-a-hotrod-ride-f6e3141f7941)
 > Note: This is for demonstration purposes only. Using an in memory database means traces will not be persisted for very long
 
-![screenshot of pgadmin](jaeger-ui.png)
+![screenshot of jaeger ui](jaeger-ui.png)
+
+## Persistent
+The `persistent.yml` manifest will deploy a `jaeger-all-in-one` instance using Elasticsearch as a persistent backing store.
 
 ## Requirements
 
-- No backing service requirements
+- Elasticsearch - `jaeger-elasticsearch` (persistent deployment only)
 
 ## Setup
 
@@ -24,19 +28,27 @@ From the `jaeger` directory, run:
 ```
 
 ## Push the apps
+All commands are using the `cf` CLI version 7 or higher.
 
+### Demo
 ```
-# Using the CF CLI version 7
-$ cf push --var deployment=my-deployment-name
+$ cf push --strategy rolling -f demo.yml jaeger-all-in-one --var deployment=my-deployment-name
+$ cf push --strategy rolling -f demo.yml jaeger-example-app --var deployment=my-deployment-name
 ```
 
-## Allow the applications to communicate with one another
+#### Allow the applications to communicate with one another
 
 ```
 $ cf add-network-policy jaeger-example-app \
     --destination-app jaeger-all-in-one \
     --port 6831 --protocol udp
 ```
+
+### Persistent
+```
+$ cf push --strategy rolling -f persistent.yml jaeger-all-in-one --var deployment=my-deployment-name
+```
+
 
 ## Authentication
 

--- a/jaeger/jaeger-all-in-one/env-map.yml
+++ b/jaeger/jaeger-all-in-one/env-map.yml
@@ -1,4 +1,5 @@
 env_vars:
-  ES_SERVER_URLS: '.elasticsearch[0].credentials | "https://\(.hostname):\(.port|tostring)"'
+  ES_HOST: ".elasticsearch[0].credentials.hostname"
+  ES_PORT: ".elasticsearch[0].credentials.port"
   ES_USERNAME: ".elasticsearch[0].credentials.username"
   ES_PASSWORD: ".elasticsearch[0].credentials.password"

--- a/jaeger/jaeger-all-in-one/env-map.yml
+++ b/jaeger/jaeger-all-in-one/env-map.yml
@@ -1,0 +1,4 @@
+env_vars:
+  ES_SERVER_URLS: '.elasticsearch[0].credentials | "https://\(.hostname):\(.port|tostring)"'
+  ES_USERNAME: ".elasticsearch[0].credentials.username"
+  ES_PASSWORD: ".elasticsearch[0].credentials.password"

--- a/jaeger/persistent.yml
+++ b/jaeger/persistent.yml
@@ -1,6 +1,7 @@
 applications:
 - name: jaeger-all-in-one
   buildpacks:
+  - https://github.com/alphagov/env-map-buildpack
   - binary_buildpack
   memory: 256M
   health-check-type: http
@@ -10,17 +11,7 @@ applications:
   - route: jaeger-((deployment)).cloudapps.digital
   path: jaeger-all-in-one
   command: ./jaeger-all-in-one --sampling.strategies-file=sampling_strategies.json --query.port=$PORT
-
-- name: jaeger-example-app
-  buildpacks:
-  - binary_buildpack
-  memory: 256M
-  health-check-type: http
-  health-check-http-endpoint: /
-  routes:
-  - route: jaeger-example-app-((deployment)).cloudapps.digital
-  path: example-app
-  command: ./example-hotrod all
+  services:
+  - jaeger-elasticsearch
   env:
-    JAEGER_AGENT_HOST: jaeger-((deployment)).apps.internal
-    JAEGER_AGENT_PORT: 6831
+    SPAN_STORAGE_TYPE: elasticsearch

--- a/jaeger/persistent.yml
+++ b/jaeger/persistent.yml
@@ -10,7 +10,13 @@ applications:
   - route: jaeger-((deployment)).apps.internal
   - route: jaeger-((deployment)).cloudapps.digital
   path: jaeger-all-in-one
-  command: ./jaeger-all-in-one --sampling.strategies-file=sampling_strategies.json --query.port=$PORT
+  command: |
+    ./jaeger-all-in-one \
+    --sampling.strategies-file=sampling_strategies.json \
+    --query.port=$PORT \
+    --es.server-urls="https://$ES_HOST:$ES_PORT" \
+    --es.username=$ES_USERNAME \
+    --es.password=$ES_PASSWORD
   services:
   - jaeger-elasticsearch
   env:


### PR DESCRIPTION
Add a persistent deployment of jaeger-all-in-one using Aiven provided Elasticsearch

I made some bold and unsubstantiated assumptions about users in the second commit so please compare 1st and 2nd and let me know if it is actually more readable.